### PR TITLE
Allow for more than 2 comment states

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -681,10 +681,10 @@ SELECT
           $author_id = 2; // guest on Piwigo
         }
 
-        $validated = 'true';
-        if ('unpublished' == $row['state'])
+        $validated = 'false';
+        if ('published' == $row['state'])
         {
-          $validated = 'false';
+          $validated = 'true';
         }
 
         $anonymous_id = implode('.', array_slice(explode('.', $row['server_remote_addr']), 0, 3));


### PR DESCRIPTION
A Gallery3 Comment can have more states than just unpublished and published. In my installation I have 
- published
- unpublished
- deleted
- spam

This change will not validate comments by default (for spam, unpublished,...) and will act on the state of "published"
