### PR TITLE
Split keywords on , and ;

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -315,7 +315,7 @@ SELECT
         // tags
         if (!empty($item['keywords']))
         {
-          foreach (explode(',', $item['keywords']) as $keyword)
+          foreach (preg_split("/[,;]+/", $item['keywords']) as $keyword)
           {
             $keyword = trim($keyword);
 


### PR DESCRIPTION
#6 added the ability to import G2 keywords, but the site I encountered had multiple keywords separated by `;`. This patch makes it split on both `,` and `;`.